### PR TITLE
[Major] DB 접속 함수 수정 및 DML 쿼리문을 수행할 DB가 지정되어 있지 않는 문제 해결

### DIFF
--- a/PMS_DB_Manage.py
+++ b/PMS_DB_Manage.py
@@ -1,15 +1,15 @@
 """
     CodeCraft PMS Project
     파일명 : PMS_DB_Manage.py
-    마지막 수정 날짜 : 2024/11/04
+    마지막 수정 날짜 : 2024/11/10
 """
 
 import pymysql
-from mysql_connection import db_connect
+from mysql_connection import *
 
 # PMS DB를 생성하는 함수
 def create_pms_db():
-    connection = db_connect()
+    connection = db_root_connect()
     cur = connection.cursor(pymysql.cursors.DictCursor)
 
     try:
@@ -26,7 +26,7 @@ def create_pms_db():
 # PMS DB를 삭제하는 함수
 # PMS DB 안에 정의되어 있는 모든 테이블과 데이터가 삭제되므로 주의하여 사용
 def drop_pms_db():
-    connection = db_connect()
+    connection = db_root_connect()
     cur = connection.cursor(pymysql.cursors.DictCursor)
 
     try:
@@ -42,7 +42,7 @@ def drop_pms_db():
 
 # PMS DB를 삭제하고 다시 생성하는 함수
 def recreate_pms_db():
-    connection = db_connect()
+    connection = db_root_connect()
     cur = connection.cursor(pymysql.cursors.DictCursor)
 
     try:
@@ -61,7 +61,7 @@ def recreate_pms_db():
 # SQL 파일을 읽어서 PMS DB에 테이블을 생성하고 관계 및 제약조건 설정, 학과 정보를 입력하는 함수
 # 주의사항 : PMS DB가 삭제된 상태에서 실행해야 한다 (SQL 파일 안에 PMS DB 생성문이 포함되어 있기 때문)
 def create_pms_db_byFile():
-    conn = db_connect()
+    conn = db_root_connect()
 
     try:
         with conn.cursor() as cur:

--- a/mysql_connection.py
+++ b/mysql_connection.py
@@ -28,6 +28,20 @@ def db_connect():
     )
     return connection
 
+# MySQL 서버에 로그인하여 접속하는 함수
+# DML 작업을 수행할 DB 대상을 지정하지 않으며, 테이블이 아닌 DB 자체를 생성하거나 삭제하는 등의 경우에 사용한다
+def db_root_connect():
+    load_dotenv()
+    password = os.getenv('DB_PASSWORD')
+
+    connection = pymysql.connect(
+        host='192.168.50.84',
+        user='root',
+        password=password,
+        charset='utf8mb4'
+    )
+    return connection
+
 # db_session = db_connect()
 
 # try: # DB에 접속해 테이블 리스트 출력

--- a/mysql_connection.py
+++ b/mysql_connection.py
@@ -5,7 +5,7 @@
    생성자   : 김창환                                
                                                                               
    생성일   : 2024/10/14
-   업데이트 : 2024/10/20
+   업데이트 : 2024/11/10
                                                                              
    설명     : API와 DB를 연결하는 기능 정의
 """
@@ -14,6 +14,7 @@ import pymysql
 from dotenv import load_dotenv
 import os
 
+# MySQL 서버에 로그인하고 PMS DB에 접속하는 함수
 def db_connect():
     load_dotenv()
     password = os.getenv('DB_PASSWORD')
@@ -22,7 +23,8 @@ def db_connect():
         host='192.168.50.84',
         user='root',
         password=password,
-        charset='utf8mb4'
+        charset='utf8mb4',
+        database='PMS'
     )
     return connection
 


### PR DESCRIPTION
## Summary
- [X] `mysql_connection.py` 의 `db_connect()` 함수에서 PMS DB를 지정하여 접속하도록 수정하였습니다.
- [X] `mysql_connection.py` 에 `db_root_connect()` 함수를 새로 추가하였습니다.

## Description
### `db_connect()` 함수
- 제가 구현한 `account_DB.py, project_DB.py, task_DB.py, output_DB.py, wbs_DB.py` 등에는 PMS DB의 특정 테이블을 대상으로 DML 쿼리문을 수행하지만, 기존의 `db_connect()` 함수는 PMS DB를 지정하여 접속하지 않도록 되어 있었습니다.
- DML 쿼리문을 수행하기 전에 `USE PMS;` 쿼리를 먼저 수행하는 방법도 있지만, 각각의 함수마다 해당 쿼리를 추가해야 하며, 코드가 중복됩니다.
- 그래서, `db_connect()` 함수에서 `pymysql.connect()` 의 매개 변수에 `database='PMS'` 항목을 추가하여, PMS DB를 지정하여 접속하도록 수정하였습니다.

> [!CAUTION]
> PMS DB에 속하는 테이블에 DML 쿼리문을 수행하는 경우에는 PMS DB를 사용하겠다는 것을 명시해야 합니다.
> 그렇지 않으면, 해당 DML 쿼리문을 수행할 테이블이 어떤 DB에 존재하는지 알 수 없으므로, 사용할 DB가 지정되지 않았다는 오류가 발생할 수 있습니다.

### `db_root_connect()` 함수
- `mysql_connection.py` 에 `db_root_connect()` 함수를 새로 추가하였습니다.
- `PMS_DB_Manage.py` 에서 PMS DB를 생성, 삭제, 다시 생성, SQL 파일로 생성하는 함수의 DB 접속 함수를 `db_connect()` 가 아닌 `db_root_connect()` 함수를 사용하도록 수정하였습니다.

> [!TIP]
> `db_root_connect()` 함수는 DML 작업을 수행할 DB 대상을 지정하지 않습니다.
> 테이블이 아닌 DB 자체를 생성하거나 삭제하는 등의 경우에 사용하기 적합합니다.