### PR TITLE
[Major] 프로젝트 참여자(팀원) 추가 함수의 매개 변수에 PM 권한도 입력받도록 수정

### DIFF
--- a/project_DB.py
+++ b/project_DB.py
@@ -137,6 +137,7 @@ def add_project_user(pid, univ_id, permission, role):
         connection.close()
 
 # 프로젝트 참여자 수정(팀원 정보 수정) 함수
+# 수정하려는 팀원의 ID, 이름, 이메일, 학번, 프로젝트 번호, 역할을 매개 변수로 받는다
 def edit_project_user(id, name, email, univ_id, pid, role):
     connection = db_connect()
     cur = connection.cursor(pymysql.cursors.DictCursor)
@@ -159,6 +160,7 @@ def edit_project_user(id, name, email, univ_id, pid, role):
         connection.close()
 
 # 프로젝트 참여자 삭제(팀원 퇴출) 함수
+# 프로젝트 번호와 퇴출하려는 팀원의 학번을 매개 변수로 받는다
 def delete_project_user(pid, univ_id):
     connection = db_connect()
     cur = connection.cursor(pymysql.cursors.DictCursor)
@@ -176,6 +178,7 @@ def delete_project_user(pid, univ_id):
         connection.close()
 
 # 프로젝트 참여자(팀원 조회) 조회 함수
+# 조회하려는 팀원이 속한 프로젝트의 프로젝트 번호를 매개 변수로 받는다
 def fetch_project_user(pid):
     connection = db_connect()
     cur = connection.cursor(pymysql.cursors.DictCursor)
@@ -193,6 +196,7 @@ def fetch_project_user(pid):
         connection.close()
 
 # 프로젝트의 중요 정보를 수정할 때 사용자의 권한(PM 권한)을 확인하는 함수
+# 프로젝트 번호와 학번을 매개 변수로 받는다
 def validate_pm_permission(pid, univ_id):
     connection = db_connect()
     cur = connection.cursor(pymysql.cursors.DictCursor)

--- a/project_DB.py
+++ b/project_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : project_DB.py
-    마지막 수정 날짜 : 2024/11/13
+    마지막 수정 날짜 : 2024/11/18
 """
 
 import pymysql
@@ -114,17 +114,18 @@ def delete_project(pid):
         connection.close()
 
 # 프로젝트 참여자 추가(팀원 초대) 함수
+# 프로젝트 번호, 학번, PM 권한 여부(0/1), 역할을 매개 변수로 받는다
 # 주의사항 : 초대하려는 사용자(학생)는 회원가입이 이미 완료되어 있어야 한다
-def add_project_user(pid, univ_id, role):
+def add_project_user(pid, univ_id, permission, role):
     connection = db_connect()
     cur = connection.cursor(pymysql.cursors.DictCursor)
 
     try:
         add_project_user = """
         INSERT INTO project_user(p_no, s_no, permission, role, grade)
-        VALUES (%s, %s, 0, %s, NULL)
+        VALUES (%s, %s, %s, %s, NULL)
         """
-        cur.execute(add_project_user, (pid, univ_id, role))
+        cur.execute(add_project_user, (pid, univ_id, permission, role))
         connection.commit()
         return True
     except Exception as e:


### PR DESCRIPTION
## Summary
- [X] 프로젝트 참여자 추가(팀원 초대) 함수의 매개 변수에 PM 권한도 입력받도록 수정하였습니다.

## Description
### add_project_user(pid, univ_id, permission, role)
- `add_project_user()` 함수를 호출할 때, 추가하려는 팀원이 PM 권한을 가지도록 할 것인지의 여부를 `Boolean` 타입으로 입력받도록 `permission` 매개 변수를 추가하였습니다.

> [!NOTE]
> 원래, 기존의 `add_project_user()` 함수는 프로젝트가 생성되어 있는 상태에서, 팀장이 아닌 팀원을 추가하는 경우에 사용하도록 만든 함수였으며, 기존에는 PM 권한을 가진 팀장을 추가할 수 있는 함수가 없었습니다.
> 팀장을 추가할 함수를 하나 더 만드는 것은 비슷한 소스 코드가 중복될 것 같아서, `add_project_user()` 함수에 매개 변수를 추가하는 방식으로 수정하였습니다.

> [!WARNING]
> 또한, 현재 프로젝트를 생성하면 프로젝트(project) 테이블에 행(레코드)이 추가되지만, 프로젝트 참여(project_user) 테이블에는 방금 만든 프로젝트에 어떤 팀원이 참여하고 있는지에 대한 정보가 자동으로 추가되지 않습니다.

> [!TIP]
> 즉, API 서버에서 프로젝트를 생성하는 `async def api_prj_init_post(payload: project_init)` 라우터 함수에서
> 1. 프로젝트를 생성하는 `init_project()` 함수를 호출하고,
> 2. `add_project_user()` 도 호출하여 프로젝트를 생성한 사람을 팀장(PM 권한을 가진 사람)으로 설정하면서 프로젝트 참여 테이블에도 추가해줘야 할 것 같습니다.