### PR TITLE
[Normal] 성적 조회 쿼리에 조인을 적용하여 프로젝트 이름과 학생 이름도 같이 조회되도록 개선

### DIFF
--- a/account_DB.py
+++ b/account_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : account_DB.py
-    마지막 수정 날짜 : 2024/11/15
+    마지막 수정 날짜 : 2024/11/21
 """
 
 import pymysql
@@ -23,7 +23,7 @@ def insert_user(payload, Token):
         return True
     except Exception as e:
         connection.rollback()
-        print(f"Error [insert_user]: {e}")
+        print(f"Error [insert_user] : {e}")
         return e
     finally:
         cur.close()

--- a/grade_DB.py
+++ b/grade_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : grade_DB.py
-    마지막 수정 날짜 : 2024/11/14
+    마지막 수정 날짜 : 2024/11/21
 """
 
 import pymysql
@@ -68,7 +68,12 @@ def fetch_grade_by_student(univ_id):
     cur = connection.cursor(pymysql.cursors.DictCursor)
 
     try:
-        cur.execute("SELECT p_no, s_no, grade FROM project_user WHERE s_no = %s", (univ_id,))
+        fetch_grade_by_student = """
+        SELECT p.p_no, p.p_name, s.s_no, s.s_name, u.grade
+        FROM student s, project p, project_user u
+        WHERE s.s_no = u.s_no AND p.p_no = u.p_no AND u.s_no = %s
+        """
+        cur.execute(fetch_grade_by_student, (univ_id,))
         result = cur.fetchall()
         return result
     except Exception as e:
@@ -85,7 +90,12 @@ def fetch_grade_by_project(pid):
     cur = connection.cursor(pymysql.cursors.DictCursor)
 
     try:
-        cur.execute("SELECT p_no, s_no, grade FROM project_user WHERE p_no = %s", (pid,))
+        fetch_grade_by_project = """
+        SELECT p.p_no, p.p_name, s.s_no, s.s_name, u.grade
+        FROM student s, project p, project_user u
+        WHERE s.s_no = u.s_no AND p.p_no = u.p_no AND u.p_no = %s
+        """
+        cur.execute(fetch_grade_by_project, (pid,))
         result = cur.fetchall()
         return result
     except Exception as e:

--- a/project_DB.py
+++ b/project_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : project_DB.py
-    마지막 수정 날짜 : 2024/11/18
+    마지막 수정 날짜 : 2024/11/21
 """
 
 import pymysql
@@ -137,7 +137,7 @@ def add_project_user(pid, univ_id, permission, role):
         connection.close()
 
 # 프로젝트 참여자 수정(팀원 정보 수정) 함수
-# 수정하려는 팀원의 ID, 이름, 이메일, 학번, 프로젝트 번호, 역할을 매개 변수로 받는다
+# 수정하려는 팀원의 학번, 프로젝트 번호, 역할을 매개 변수로 받는다
 def edit_project_user(univ_id, pid, role):
     connection = db_connect()
     cur = connection.cursor(pymysql.cursors.DictCursor)


### PR DESCRIPTION
## Summary
- [X] 프로젝트 평가(성적) 점수를 조회하는 쿼리에 3개의 테이블을 조인하여 프로젝트 이름과 학생 이름도 같이 조회되도록 수정 및 개선하였습니다.

## Description
- 기존에는 `p_no`, `s_no`, `grade` 3개의 컬럼을 조회하기 때문에 프로젝트 번호, 학번, 성적만 출력되며, 프로젝트 이름과 학생 이름이 없기 때문에, 어떤 프로젝트이고 학생 이름이 무엇인지 한 눈에 파악하기가 조금 어렵고 불편할 수 있습니다.
- 그래서, `student`, `project`, `project_user` 3개의 테이블을 조인하여 프로젝트 이름과 학생 이름도 같이 출력되도록 쿼리문을 수정 및 개선하였습니다.
- 수정된 프로젝트 평가(성적) 점수 조회 함수
  - `fetch_grade_by_student(univ_id)`
  - `fetch_grade_by_project(pid)`

> [!NOTE]
> `fetch_one_grade(pid, univ_id)` 함수는 학생 한 명의 특정 프로젝트 하나만 조회하여 성적만 반환하는 쿼리이기 때문에, 이 함수는 조인을 사용하도록 수정하지 않았습니다.