### PR TITLE
[Severe] 존재하지 않는 PID로 프로젝트가 삭제되는 버그 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,12 @@ __pycache__/
 Backend\ Project/
 Database\ Project/
 account.py
+docs_converter.py
+grade.py
 main.py
 output.py
 project.py
 task.py
 test.py
+upload.py
+wbs.py

--- a/project_DB.py
+++ b/project_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : project_DB.py
-    마지막 수정 날짜 : 2024/11/21
+    마지막 수정 날짜 : 2024/11/24
 """
 
 import pymysql
@@ -97,6 +97,15 @@ def delete_project(pid):
     cur = connection.cursor(pymysql.cursors.DictCursor)
     
     try:
+        # 매개 변수로 받은 pid 값을 가진 프로젝트가 존재하는지 확인하기 위해 COUNT 함수를 사용
+        cur.execute("SELECT COUNT(*) AS cnt FROM project WHERE p_no = %s", (pid,))
+        result = cur.fetchone()
+
+        # 매개 변수로 받은 pid 값을 가진 프로젝트가 존재하지 않으면 오류 메시지 출력 및 False 반환
+        if result['cnt'] == 0:
+            print(f"Error [delete_project] : Project UID {pid} does not exist.")
+            return False
+        
         # 프로젝트 테이블에서 매개 변수로 받은 프로젝트 삭제
         cur.execute("DELETE FROM project WHERE p_no = %s", (pid,))
         connection.commit()


### PR DESCRIPTION
## Summary
- [X] `project_DB.py` 의 프로젝트 삭제 함수에서 매개 변수로 받은 `pid` 값을 가진 프로젝트가 DB에 존재하는지 확인하는 로직을 추가하여 개선하였습니다.
  - 해당 이슈 : #18

## Description
- `delete_project(pid)` 함수에서 `DELETE` 쿼리를 수행하기 전에, 매개 변수로 받은 `pid` 값을 가진 프로젝트가 존재하는지 먼저 확인하도록 수정하여 개선하였습니다.

> [!NOTE]
> 매개 변수로 받은 `pid` 값을 가진 프로젝트가 존재하지 않으면, 오류 메시지를 출력하며 `False` 를 반환합니다.
> 매개 변수로 받은 `pid` 값을 가진 프로젝트가 존재하면, 해당 프로젝트를 삭제합니다.