### PR TITLE
[Major] 기타 산출물 테이블에 학번 외래키 추가

### DIFF
--- a/PMS_Tables_Define.sql
+++ b/PMS_Tables_Define.sql
@@ -33,6 +33,7 @@ CREATE TABLE doc_other (
  file_name VARCHAR(300) NOT NULL,
  file_path VARCHAR(1000) NOT NULL,
  file_date DATETIME NOT NULL,
+ s_no INT NOT NULL,
  p_no INT NOT NULL
 );
 
@@ -147,6 +148,7 @@ CREATE TABLE doc_report (
 ALTER TABLE student ADD CONSTRAINT FK_dept_TO_student_1 FOREIGN KEY (dno) REFERENCES dept (dno);
 ALTER TABLE project_user ADD CONSTRAINT FK_project_TO_project_user_1 FOREIGN KEY (p_no) REFERENCES project (p_no) ON DELETE CASCADE;
 ALTER TABLE project_user ADD CONSTRAINT FK_student_TO_project_user_1 FOREIGN KEY (s_no) REFERENCES student (s_no) ON DELETE CASCADE;
+ALTER TABLE doc_other ADD CONSTRAINT FK_student_TO_doc_other_1 FOREIGN KEY (s_no) REFERENCES student (s_no);
 ALTER TABLE doc_other ADD CONSTRAINT FK_project_TO_doc_other_1 FOREIGN KEY (p_no) REFERENCES project (p_no) ON DELETE CASCADE;
 ALTER TABLE progress ADD CONSTRAINT FK_project_TO_progress_1 FOREIGN KEY (p_no) REFERENCES project (p_no) ON DELETE CASCADE;
 ALTER TABLE project ADD CONSTRAINT FK_dept_TO_project_1 FOREIGN KEY (dno) REFERENCES dept (dno);

--- a/output_DB.py
+++ b/output_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : output_DB.py
-    마지막 수정 날짜 : 2024/11/14
+    마지막 수정 날짜 : 2024/11/28
 """
 
 import pymysql
@@ -489,17 +489,17 @@ def fetch_all_testcase(pid):
 
 # ------------------------------ 기타 산출물 ------------------------------ #
 # 기타 산출물을 추가하는 함수
-# 추가하려는 기타 산출물의 산출물 고유 번호, 파일 이름, 파일 경로, 프로젝트 번호를 매개 변수로 받는다
-def add_other_document(file_unique_id, file_name, file_path, file_date, pid):
+# 추가하려는 기타 산출물의 산출물 고유 번호, 파일 이름, 파일 경로, 업로드 날짜, 학번, 프로젝트 번호를 매개 변수로 받는다
+def add_other_document(file_unique_id, file_name, file_path, file_date, univ_id, pid):
     connection = db_connect()
     cur = connection.cursor(pymysql.cursors.DictCursor)
 
     try:
         add_doc_other = """
-        INSERT INTO doc_other (file_no, file_name, file_path, file_date, p_no)
-        VALUES (%s, %s, %s, %s, %s)
+        INSERT INTO doc_other (file_no, file_name, file_path, file_date, s_no, p_no)
+        VALUES (%s, %s, %s, %s, %s, %s)
         """
-        cur.execute(add_doc_other, (file_unique_id, file_name, file_path, file_date, pid))
+        cur.execute(add_doc_other, (file_unique_id, file_name, file_path, file_date, univ_id, pid))
         connection.commit()
         return True
     except Exception as e:


### PR DESCRIPTION
## Summary
- [X] `doc_other` 테이블에 학번 외래키를 추가하였습니다.
  - https://github.com/CodeCraft-NSU/Database/issues/19

## Description
- Issues 19번의 첫 번째 항목에 대한 수정 작업이며, `doc_other` 테이블에 학번 외래키를 추가하였습니다.
- 온라인 산출물을 파일로 직접 업로드할 때, DB에 정보를 저장하는 함수는 `add_other_document()` 입니다.

> [!IMPORTANT]
> `add_other_document()` 함수를 호출할 때, 파일 경로는 API에서 제공한 것으로 매개 변수에 넣어서 호출합니다.

### 온라인으로 작성하는 산출물
- WBS(진척도) : 사용자가 웹에서 양식대로 입력받은 내용을 progress 테이블의 컬럼에 맞게 저장
- 회의록 : 사용자가 웹에서 양식대로 입력받은 내용을 doc_meeting 테이블의 컬럼에 맞게 저장
- 프로젝트 개요서(간단본 및 상세본) : 사용자가 웹에서 양식대로 입력받은 내용을 doc_summary 테이블의 컬럼에 맞게 저장
- 요구사항 명세서 : 사용자가 웹에서 양식대로 입력받은 내용을 doc_require 테이블의 컬럼에 맞게 저장
- 테스트 케이스 : 사용자가 웹에서 양식대로 입력받은 내용을 doc_test 테이블의 컬럼에 맞게 저장
- 보고서 : 사용자가 웹에서 양식대로 입력받은 내용을 doc_report 테이블의 컬럼에 맞게 저장

### 온라인 산출물을 파일로 직접 업로드, 기타 산출물 업로드
- WBS(진척도) : add_other_document() 함수로 doc_other 테이블에 저장
- 회의록 : add_other_document() 함수로 doc_other 테이블에 저장
- 프로젝트 개요서(간단본 및 상세본) : add_other_document() 함수로 doc_other 테이블에 저장
- 요구사항 명세서 : add_other_document() 함수로 doc_other 테이블에 저장
- 테스트 케이스 : add_other_document() 함수로 doc_other 테이블에 저장
- 보고서 : add_other_document() 함수로 doc_other 테이블에 저장
- 기타 산출물 : add_other_document() 함수로 doc_other 테이블에 저장
