### PR TITLE
[Normal] LLM에 프로젝트 관련 정보를 JSON 형식으로 제공하는 쿼리 및 함수 구현

### DIFF
--- a/project_DB.py
+++ b/project_DB.py
@@ -1,10 +1,11 @@
 """
     CodeCraft PMS Project
     파일명 : project_DB.py
-    마지막 수정 날짜 : 2024/11/24
+    마지막 수정 날짜 : 2024/11/28
 """
 
 import pymysql
+import json
 from mysql_connection import db_connect
 from project import *
 
@@ -238,31 +239,48 @@ def is_uid_exists(uid):
         connection.close()
 
 # LLM에 제공할 프로젝트의 모든 정보를 반환하는 함수
-# 프로젝트 번호를 매개 변수로 받으며, 프로젝트와 업무, 진척도, 모든 산출물 테이블을 조인하여 조회한 결과를 반환한다
+# 프로젝트 번호를 매개 변수로 받아서 프로젝트와 업무, 진척도, 모든 산출물 테이블을 각각 조회하고 JSON으로 가공하여 반환한다
 def fetch_project_for_LLM(pid):
     connection = db_connect()
-    cur = connection.cursor(pymysql.cursors.DictCursor)
+    cur = connection.cursor()
 
     try:
-        fetch_project_for_LLM = """
-        SELECT *
-        FROM (
-            SELECT * 
-            FROM project 
-            WHERE p_no = %s
-        ) p
-        LEFT JOIN work w ON p.p_no = w.p_no
-        LEFT JOIN progress pg ON p.p_no = pg.p_no
-        LEFT JOIN doc_meeting dm ON p.p_no = dm.p_no
-        LEFT JOIN doc_summary ds ON p.p_no = ds.p_no
-        LEFT JOIN doc_require dr ON p.p_no = dr.p_no
-        LEFT JOIN doc_test dt ON p.p_no = dt.p_no
-        LEFT JOIN doc_report drep ON p.p_no = drep.p_no
-        LEFT JOIN doc_other do ON p.p_no = do.p_no
-        """
-        cur.execute(fetch_project_for_LLM, (pid,))
-        result = cur.fetchall()
-        return result
+        cur.execute("SELECT p_no, p_name, p_content, p_method, p_memcount, p_start, p_end FROM project WHERE p_no = %s", (pid,))
+        project = cur.fetchone()
+
+        cur.execute("SELECT w_name, w_person, w_start, w_end, w_checked FROM work WHERE p_no = %s", (pid,))
+        work_list = cur.fetchall()
+
+        cur.execute("SELECT group1, group2, group3, work, output_file, manager, ratio, start_date, end_date FROM progress WHERE p_no = %s", (pid,))
+        progress_list = cur.fetchall()
+
+        cur.execute("SELECT * FROM doc_meeting WHERE p_no = %s", (pid,))
+        meeting_list = cur.fetchall()
+
+        cur.execute("SELECT * FROM doc_summary WHERE p_no = %s", (pid,))
+        summary_list = cur.fetchall()
+
+        cur.execute("SELECT * FROM doc_require WHERE p_no = %s", (pid,))
+        requirement_list = cur.fetchall()
+
+        cur.execute("SELECT * FROM doc_test WHERE p_no = %s", (pid,))
+        test_list = cur.fetchall()
+
+        cur.execute("SELECT * FROM doc_report WHERE p_no = %s", (pid,))
+        report_list = cur.fetchall()
+
+        project_data = {
+            "project": project,
+            "work_list": work_list,
+            "progress_list": progress_list,
+            "meeting_list": meeting_list,
+            "summary_list": summary_list,
+            "requirement_list": requirement_list,
+            "test_list": test_list,
+            "report_list": report_list
+        }
+
+        return json.dumps(project_data, ensure_ascii=False, default=str)
     except Exception as e:
         print(f"Error [fetch_project_for_LLM] : {e}")
         return e

--- a/project_DB.py
+++ b/project_DB.py
@@ -249,7 +249,7 @@ def fetch_project_for_LLM(pid):
         FROM (
             SELECT * 
             FROM project 
-            WHERE p_no = 28405
+            WHERE p_no = %s
         ) p
         LEFT JOIN work w ON p.p_no = w.p_no
         LEFT JOIN progress pg ON p.p_no = pg.p_no

--- a/project_DB.py
+++ b/project_DB.py
@@ -236,3 +236,36 @@ def is_uid_exists(uid):
     finally:
         cur.close()
         connection.close()
+
+# LLM에 제공할 프로젝트의 모든 정보를 반환하는 함수
+# 프로젝트 번호를 매개 변수로 받으며, 프로젝트와 업무, 진척도, 모든 산출물 테이블을 조인하여 조회한 결과를 반환한다
+def fetch_project_for_LLM(pid):
+    connection = db_connect()
+    cur = connection.cursor(pymysql.cursors.DictCursor)
+
+    try:
+        fetch_project_for_LLM = """
+        SELECT *
+        FROM (
+            SELECT * 
+            FROM project 
+            WHERE p_no = 28405
+        ) p
+        LEFT JOIN work w ON p.p_no = w.p_no
+        LEFT JOIN progress pg ON p.p_no = pg.p_no
+        LEFT JOIN doc_meeting dm ON p.p_no = dm.p_no
+        LEFT JOIN doc_summary ds ON p.p_no = ds.p_no
+        LEFT JOIN doc_require dr ON p.p_no = dr.p_no
+        LEFT JOIN doc_test dt ON p.p_no = dt.p_no
+        LEFT JOIN doc_report drep ON p.p_no = drep.p_no
+        LEFT JOIN doc_other do ON p.p_no = do.p_no
+        """
+        cur.execute(fetch_project_for_LLM, (pid,))
+        result = cur.fetchall()
+        return result
+    except Exception as e:
+        print(f"Error [fetch_project_for_LLM] : {e}")
+        return e
+    finally:
+        cur.close()
+        connection.close()


### PR DESCRIPTION
## Summary
- [X] `project_DB.py` 에서 LLM에 프로젝트 관련 정보를 JSON 형식으로 제공하는 쿼리 및 함수를 구현하였습니다.

## Description
- `def fetch_project_for_LLM(pid)`
  - 프로젝트, 업무, 진척도, 기타 산출물을 제외한 나머지 모든 산출물 테이블의 정보를 개별로 조회하고, 이를 JSON 형식으로 가공하여 반환합니다.

> [!NOTE]
> SQL 커서는 딕셔너리 형태로 조회하는 `cursor(pymysql.cursors.DictCursor)` 가 아닌 튜플 형태로 조회하는 `cursor()` 기본값 커서를 사용합니다.