### PR TITLE
[Normal] DB 및 ERD에서 불필요한 산출물 경로 컬럼 삭제

### DIFF
--- a/PMS_Tables_Define.sql
+++ b/PMS_Tables_Define.sql
@@ -93,7 +93,6 @@ CREATE TABLE doc_require (
  doc_r_s_name TEXT NULL,
  doc_r_s_content TEXT NULL,
  doc_r_date DATE NOT NULL,
- doc_r_path VARCHAR(1000) NULL,
  p_no INT NOT NULL
 );
 
@@ -106,7 +105,6 @@ CREATE TABLE doc_meeting (
  doc_m_manager TEXT NOT NULL,
  doc_m_content TEXT NOT NULL,
  doc_m_result TEXT NOT NULL,
- doc_m_path VARCHAR(1000) NULL,
  p_no INT NOT NULL
 );
 
@@ -122,7 +120,6 @@ CREATE TABLE doc_summary (
  doc_s_start DATE NOT NULL,
  doc_s_end DATE NOT NULL,
  doc_s_date DATE NOT NULL,
- doc_s_path VARCHAR(1000) NULL,
  p_no INT NOT NULL
 );
 
@@ -141,7 +138,6 @@ CREATE TABLE doc_report (
  doc_rep_content TEXT NOT NULL,
  doc_rep_writer TEXT NOT NULL,
  doc_rep_date DATE NOT NULL,
- doc_rep_path VARCHAR(1000) NULL,
  p_no INT NOT NULL
 );
 


### PR DESCRIPTION
## Summary
- [X] `PMS_Tables_Define.sql` 의 일부 산출물 테이블에서 불필요한 산출물 경로 컬럼을 삭제하였습니다.

## Description
- `doc_summary`, `doc_require`, `doc_meeting`, `doc_report` 테이블에서 산출물 경로 컬럼을 삭제하였습니다.
- 기타 산출물 테이블은 필요 및 사용되므로 당연히 삭제하지 않고 그대로 두었습니다.

> [!NOTE]
> 위의 컬럼을 삭제하여도, 이에 영향을 받거나 수정해야 하는 쿼리 함수는 없습니다.
> 또한, 수정한 내용대로 ERD와 테이블 정의서도 수정하여 GitHub 산출물 저장소에 업로드하였습니다.