### PR TITLE
[Normal] 권한 구체화 작업에 따른 권한 테이블 생성, 권한 관련 쿼리 및 함수 구현, Etc

### DIFF
--- a/PMS_Tables_Define.sql
+++ b/PMS_Tables_Define.sql
@@ -150,6 +150,24 @@ CREATE TABLE doc_report (
  p_no INT NOT NULL
 );
 
+CREATE TABLE permission (
+ p_no INT NOT NULL,
+ s_no INT NOT NULL,
+ leader TINYINT NOT NULL,
+ ro TINYINT NOT NULL,
+ user TINYINT NOT NULL,
+ wbs TINYINT NOT NULL,
+ od TINYINT NOT NULL,
+ mm TINYINT NOT NULL,
+ ut TINYINT NOT NULL,
+ rs TINYINT NOT NULL,
+ rp TINYINT NOT NULL,
+ om TINYINT NOT NULL,
+ task TINYINT NOT NULL,
+ llm TINYINT NOT NULL,
+ PRIMARY KEY (p_no, s_no)
+);
+
 ALTER TABLE student ADD CONSTRAINT FK_dept_TO_student_1 FOREIGN KEY (dno) REFERENCES dept (dno);
 ALTER TABLE project_user ADD CONSTRAINT FK_project_TO_project_user_1 FOREIGN KEY (p_no) REFERENCES project (p_no) ON DELETE CASCADE;
 ALTER TABLE project_user ADD CONSTRAINT FK_student_TO_project_user_1 FOREIGN KEY (s_no) REFERENCES student (s_no) ON DELETE CASCADE;
@@ -163,6 +181,7 @@ ALTER TABLE doc_meeting ADD CONSTRAINT FK_project_TO_doc_meeting_1 FOREIGN KEY (
 ALTER TABLE doc_summary ADD CONSTRAINT FK_project_TO_doc_summary_1 FOREIGN KEY (p_no) REFERENCES project (p_no) ON DELETE CASCADE;
 ALTER TABLE doc_test ADD CONSTRAINT FK_project_TO_doc_test_1 FOREIGN KEY (p_no) REFERENCES project (p_no) ON DELETE CASCADE;
 ALTER TABLE doc_report ADD CONSTRAINT FK_project_TO_doc_report_1 FOREIGN KEY (p_no) REFERENCES project (p_no) ON DELETE CASCADE;
+ALTER TABLE permission ADD CONSTRAINT FK_project_user_TO_permission FOREIGN KEY (p_no, s_no) REFERENCES project_user (p_no, s_no) ON DELETE CASCADE;
 
 ALTER TABLE project_user ADD CONSTRAINT CK_project_user_grade CHECK (grade IN ('A+', 'A', 'B+', 'B', 'C+', 'C', 'D+', 'D', 'F'));
 

--- a/csv_DB.py
+++ b/csv_DB.py
@@ -77,7 +77,7 @@ def export_csv(pid):
 # }
 # 위와 같이 딕셔너리를 만들고, import_csv(csv_dict, pid) 와 같이 함수를 호출하여 사용한다
 # 참고 : pid 매개 변수는 프로젝트를 Import 하기 전에 기존의 프로젝트 내용을 삭제하는 데에 사용된다
-# 참고 : 딕셔너리의 키는 수정이 불가능하며, 값은 /var/lib/mysql-files 경로 대신에 실제 CSV 파일이 저장되어 있는 다른 경로로 변경할 수 있다
+# 참고 : 딕셔너리의 키는 수정이 불가능하며, CSV 파일은 /var/lib/mysql/csv 경로에 저장되어 있어야 한다
 def import_csv(file_paths, pid):
     connection = db_connect()
     cur = connection.cursor(pymysql.cursors.DictCursor)

--- a/csv_DB.py
+++ b/csv_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : csv_DB.py
-    마지막 수정 날짜 : 2025/01/10
+    마지막 수정 날짜 : 2025/01/15
 """
 
 import pymysql
@@ -28,6 +28,9 @@ def export_csv(pid):
 
         save_csv_project_user = f"SELECT p_no, s_no, permission, role, grade FROM project_user WHERE p_no = {pid} INTO OUTFILE '{csv_path}project_user_{pid}_{save_time}.csv' FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n'"
         cur.execute(save_csv_project_user)
+
+        save_csv_permission = f"SELECT p_no, s_no, leader, ro, user, wbs, od, mm, ut, rs, rp, om, task, llm FROM permission WHERE p_no = {pid} INTO OUTFILE '{csv_path}permission_{pid}_{save_time}.csv' FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n'"
+        cur.execute(save_csv_permission)
 
         save_csv_work = f"SELECT w_no, w_name, w_person, w_start, w_end, w_checked, p_no, s_no FROM work WHERE p_no = {pid} INTO OUTFILE '{csv_path}work_{pid}_{save_time}.csv' FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n'"
         cur.execute(save_csv_work)
@@ -66,6 +69,7 @@ def export_csv(pid):
 #     "student" : "/var/lib/mysql/csv/student_10001_250105-153058.csv",
 #     "project" : "/var/lib/mysql/csv/project_10001_250105-153058.csv",
 #     "project_user" : "/var/lib/mysql/csv/project_user_10001_250105-153058.csv",
+#     "permission" : "/var/lib/mysql/csv/permission_10001_250105-153058.csv",
 #     "work" : "/var/lib/mysql/csv/work_10001_250105-153058.csv",
 #     "progress" : "/var/lib/mysql/csv/progress_10001_250105-153058.csv",
 #     "doc_summary" : "/var/lib/mysql/csv/doc_s_10001_250105-153058.csv",
@@ -114,6 +118,15 @@ def import_csv(file_paths, pid):
             except Exception as e:
                 print(f"Error [import_csv :: project_user] : {e}")
                 import_fail.append("project_user")
+
+        if "permission" in file_paths:
+            try:
+                load_csv_permission = f"LOAD DATA INFILE '{file_paths['permission']}' INTO TABLE permission FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n' (p_no, s_no, leader, ro, user, wbs, od, mm, ut, rs, rp, om, task, llm)"
+                cur.execute(load_csv_permission)
+                import_ok.append("permission")
+            except Exception as e:
+                print(f"Error [import_csv :: permission] : {e}")
+                import_fail.append("permission")
 
         if "work" in file_paths:
             try:

--- a/permission_DB.py
+++ b/permission_DB.py
@@ -1,0 +1,8 @@
+"""
+    CodeCraft PMS Project
+    파일명 : permission_DB.py
+    마지막 수정 날짜 : 2025/01/14
+"""
+
+import pymysql
+from mysql_connection import db_connect

--- a/permission_DB.py
+++ b/permission_DB.py
@@ -117,6 +117,40 @@ def add_manual_permission(pid, univ_id, leader, ro, user, wbs, od, mm, ut, rs, r
         cur.close()
         connection.close()
 
+# 사용자의 권한 정보를 수정하는 함수
+# 프로젝트 번호, 학번, 12개의 권한 정보를 매개 변수로 받는다
+def edit_permission(pid, univ_id, leader, ro, user, wbs, od, mm, ut, rs, rp, om, task, llm):
+    connection = db_connect()
+    cur = connection.cursor(pymysql.cursors.DictCursor)
+
+    try:
+        edit_permission = """
+        UPDATE permission
+        SET leader = %s,
+            ro = %s,
+            user = %s,
+            wbs = %s,
+            od = %s,
+            mm = %s,
+            ut = %s,
+            rs = %s,
+            rp = %s,
+            om = %s,
+            task = %s,
+            llm = %s
+        WHERE p_no = %s AND s_no = %s
+        """
+        cur.execute(edit_permission, (leader, ro, user, wbs, od, mm, ut, rs, rp, om, task, llm, pid, univ_id))
+        connection.commit()
+        return True
+    except Exception as e:
+        connection.rollback()
+        print(f"Error [edit_permission] : {e}")
+        return e
+    finally:
+        cur.close()
+        connection.close()
+
 # 프로젝트의 중요 정보를 수정할 때 사용자가 팀장(리더) 권한을 보유하고 있는지 확인(검증)하는 함수
 # 프로젝트 번호와 학번을 매개 변수로 받는다
 def validate_leader_permission(pid, univ_id):

--- a/permission_DB.py
+++ b/permission_DB.py
@@ -7,6 +7,116 @@
 import pymysql
 from mysql_connection import db_connect
 
+# 팀장의 권한 정보를 추가하는 함수
+# 프로젝트 번호와 학번을 매개 변수로 받는다
+def add_leader_permission(pid, univ_id):
+    connection = db_connect()
+    cur = connection.cursor(pymysql.cursors.DictCursor)
+
+    try:
+        add_leader_permission = """
+        INSERT INTO permission(p_no, s_no, leader, ro, user, wbs, od, mm, ut, rs, rp, om, task, llm)
+        VALUES (%s, %s, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        """
+        cur.execute(add_leader_permission, (pid, univ_id))
+        connection.commit()
+        return True
+    except Exception as e:
+        connection.rollback()
+        print(f"Error [add_leader_permission] : {e}")
+        return e
+    finally:
+        cur.close()
+        connection.close()
+
+# 관전자 모드 사용자의 권한 정보를 추가하는 함수
+# 프로젝트 번호와 학번을 매개 변수로 받는다
+def add_ro_permission(pid, univ_id):
+    connection = db_connect()
+    cur = connection.cursor(pymysql.cursors.DictCursor)
+
+    try:
+        add_ro_permission = """
+        INSERT INTO permission(p_no, s_no, leader, ro, user, wbs, od, mm, ut, rs, rp, om, task, llm)
+        VALUES (%s, %s, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        """
+        cur.execute(add_ro_permission, (pid, univ_id))
+        connection.commit()
+        return True
+    except Exception as e:
+        connection.rollback()
+        print(f"Error [add_ro_permission] : {e}")
+        return e
+    finally:
+        cur.close()
+        connection.close()
+
+# 관전자 모드 사용자의 권한 정보를 추가하는 함수 Ver2 (ro 컬럼 대신에 다른 권한을 모두 읽기 전용으로 설정)
+# 프로젝트 번호와 학번을 매개 변수로 받는다
+def add_ro_permission2(pid, univ_id):
+    connection = db_connect()
+    cur = connection.cursor(pymysql.cursors.DictCursor)
+
+    try:
+        add_ro_permission2 = """
+        INSERT INTO permission(p_no, s_no, leader, ro, user, wbs, od, mm, ut, rs, rp, om, task, llm)
+        VALUES (%s, %s, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 0)
+        """
+        cur.execute(add_ro_permission2, (pid, univ_id))
+        connection.commit()
+        return True
+    except Exception as e:
+        connection.rollback()
+        print(f"Error [add_ro_permission2] : {e}")
+        return e
+    finally:
+        cur.close()
+        connection.close()
+
+# 일반적인 팀원의 기본값 권한 정보를 추가하는 함수
+# 프로젝트 번호와 학번을 매개 변수로 받는다
+def add_default_user_permission(pid, univ_id):
+    connection = db_connect()
+    cur = connection.cursor(pymysql.cursors.DictCursor)
+
+    try:
+        add_default_user_permission = """
+        INSERT INTO permission(p_no, s_no, leader, ro, user, wbs, od, mm, ut, rs, rp, om, task, llm)
+        VALUES (%s, %s, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2)
+        """
+        cur.execute(add_default_user_permission, (pid, univ_id))
+        connection.commit()
+        return True
+    except Exception as e:
+        connection.rollback()
+        print(f"Error [add_default_user_permission] : {e}")
+        return e
+    finally:
+        cur.close()
+        connection.close()
+
+# 사용자의 권한 정보를 수동으로 추가하는 함수
+# 프로젝트 번호, 학번, 12개의 권한 정보를 매개 변수로 받는다
+def add_manual_permission(pid, univ_id, leader, ro, user, wbs, od, mm, ut, rs, rp, om, task, llm):
+    connection = db_connect()
+    cur = connection.cursor(pymysql.cursors.DictCursor)
+
+    try:
+        add_manual_permission = """
+        INSERT INTO permission(p_no, s_no, leader, ro, user, wbs, od, mm, ut, rs, rp, om, task, llm)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        """
+        cur.execute(add_manual_permission, (pid, univ_id, leader, ro, user, wbs, od, mm, ut, rs, rp, om, task, llm))
+        connection.commit()
+        return True
+    except Exception as e:
+        connection.rollback()
+        print(f"Error [add_manual_permission] : {e}")
+        return e
+    finally:
+        cur.close()
+        connection.close()
+
 # 프로젝트의 중요 정보를 수정할 때 사용자가 팀장(리더) 권한을 보유하고 있는지 확인(검증)하는 함수
 # 프로젝트 번호와 학번을 매개 변수로 받는다
 def validate_leader_permission(pid, univ_id):

--- a/permission_DB.py
+++ b/permission_DB.py
@@ -151,6 +151,40 @@ def edit_permission(pid, univ_id, leader, ro, user, wbs, od, mm, ut, rs, rp, om,
         cur.close()
         connection.close()
 
+# 특정 프로젝트에서 모든 팀원의 모든 권한을 조회하는 함수
+# 프로젝트 번호를 매개 변수로 받는다
+def fetch_all_permissions_of_all_users(pid):
+    connection = db_connect()
+    cur = connection.cursor(pymysql.cursors.DictCursor)
+
+    try:
+        cur.execute("SELECT * FROM permission WHERE p_no = %s", (pid,))
+        result = cur.fetchall()
+        return result
+    except Exception as e:
+        print(f"Error [fetch_all_permissions_of_all_users] : {e}")
+        return e
+    finally:
+        cur.close()
+        connection.close()
+
+# 특정 프로젝트에서 특정 팀원의 모든 권한을 조회하는 함수
+# 프로젝트 번호와 학번을 매개 변수로 받는다
+def fetch_all_permissions_of_user(pid, univ_id):
+    connection = db_connect()
+    cur = connection.cursor(pymysql.cursors.DictCursor)
+
+    try:
+        cur.execute("SELECT * FROM permission WHERE p_no = %s AND s_no = %s", (pid, univ_id))
+        result = cur.fetchone()
+        return result
+    except Exception as e:
+        print(f"Error [fetch_all_permissions_of_user] : {e}")
+        return e
+    finally:
+        cur.close()
+        connection.close()
+
 # 프로젝트의 중요 정보를 수정할 때 사용자가 팀장(리더) 권한을 보유하고 있는지 확인(검증)하는 함수
 # 프로젝트 번호와 학번을 매개 변수로 받는다
 def validate_leader_permission(pid, univ_id):

--- a/permission_DB.py
+++ b/permission_DB.py
@@ -6,3 +6,24 @@
 
 import pymysql
 from mysql_connection import db_connect
+
+# 프로젝트의 중요 정보를 수정할 때 사용자가 팀장(리더) 권한을 보유하고 있는지 확인(검증)하는 함수
+# 프로젝트 번호와 학번을 매개 변수로 받는다
+def validate_leader_permission(pid, univ_id):
+    connection = db_connect()
+    cur = connection.cursor(pymysql.cursors.DictCursor)
+
+    try:
+        cur.execute("SELECT leader FROM permission WHERE p_no = %s AND s_no = %s", (pid, univ_id))
+        row = cur.fetchone()
+
+        if row['leader'] == 1:
+            return True
+        else:
+            return False
+    except Exception as e:
+        print(f"Error [validate_leader_permission] : {e}")
+        return e
+    finally:
+        cur.close()
+        connection.close()

--- a/project_DB.py
+++ b/project_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : project_DB.py
-    마지막 수정 날짜 : 2025/01/09
+    마지막 수정 날짜 : 2025/01/14
 """
 
 import pymysql
@@ -211,7 +211,6 @@ def fetch_project_user(pid):
     finally:
         cur.close()
         connection.close()
-
 
 # 프로젝트의 중요 정보를 수정할 때 사용자의 권한(PM 권한)을 확인하는 함수
 # 프로젝트 번호와 학번을 매개 변수로 받는다


### PR DESCRIPTION
## Summary
- [X] `PMS_Tables_Define.sql` 에서 `permission` 테이블을 추가하고 프로젝트 참여 테이블과 외래키 제약조건을 설정하였습니다.
- [X] `permission_DB.py` 에서 권한 구체화 작업에 따른 권한 관련 쿼리 및 함수를 구현하였습니다.
  - https://github.com/CodeCraft-NSU/Backend/issues/18
- [X] `csv_DB.py` 에서 프로젝트 Import/Export 기능에 권한 정보도 추가하였습니다.

> [!NOTE]
> 그 외에, `project_DB.py` 에서는 함수 간의 줄 간격을 수정하였습니다.
> 함수 및 소스 코드 내용의 수정은 없습니다.

## Description
- 권한 정보를 추가하는 함수
  - `def add_leader_permission(pid, univ_id)`
  - `def add_ro_permission(pid, univ_id)`
  - `def add_ro_permission2(pid, univ_id)`
  - `def add_default_user_permission(pid, univ_id)`
  - `def add_manual_permission(pid, univ_id, leader, ro, user, wbs, od, mm, ut, rs, rp, om, task, llm)`
- 권한 정보를 수정하는 함수
  - `def edit_permission(pid, univ_id, leader, ro, user, wbs, od, mm, ut, rs, rp, om, task, llm)`
- 권한 정보를 조회하는 함수
  - `def fetch_all_permissions_of_all_users(pid)`
  - `def fetch_all_permissions_of_user(pid, univ_id)`
- 특정 프로젝트에서 현재 사용자가 팀장 권한을 보유하고 있는지 확인(검증)하는 함수
  - `def validate_leader_permission(pid, univ_id)`
    - 기존의 `validate_pm_permission(pid, univ_id)` 함수와 동일한 기능을 하는 함수입니다.
    - `project_user` 테이블의 `permission` 컬럼이 아닌, `permission` 테이블의 `leader` 컬럼의 값을 확인합니다.

> [!IMPORTANT]
> 권한 정보를 삭제하는 함수는 없습니다.
> 프로젝트를 삭제하면 해당 프로젝트에 참여하고 있는 모든 팀원의 권한 정보도 같이 삭제됩니다.
> 또한, PMS 를 사용하면서 메뉴/기능에 접근할 때 API 서버에서 권한 체크를 할 것 같으므로, 특정 팀원의 권한 정보가 없으면 PMS 를 정상적으로 사용하기가 어려울 것 같습니다.