### PR TITLE
[Normal] WBS 대분류 항목별로 진척률의 평균 조회, 산출물 종류를 확인하는 쿼리 및 함수 구현

### DIFF
--- a/output_DB.py
+++ b/output_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : output_DB.py
-    마지막 수정 날짜 : 2025/01/17
+    마지막 수정 날짜 : 2025/01/18
 """
 
 import pymysql
@@ -744,6 +744,13 @@ def fetch_document_type(file_unique_id):
     cur = connection.cursor(pymysql.cursors.DictCursor)
 
     try:
+        cur.execute("SELECT COUNT(*) AS cnt FROM doc_other WHERE file_no = %s", (file_unique_id,))
+        row = cur.fetchone()
+
+        if row['cnt'] == 0:
+            print(f"Error [fetch_document_type] : File Unique ID {file_unique_id} does not exist.")
+            return False
+
         cur.execute("SELECT SUBSTRING_INDEX(SUBSTRING_INDEX(file_path, '/', 5), '/', -1) AS doc_type FROM doc_other WHERE file_no = %s", (file_unique_id,))
         result = cur.fetchone()
         return result['doc_type']

--- a/output_DB.py
+++ b/output_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : output_DB.py
-    마지막 수정 날짜 : 2025/01/05
+    마지막 수정 날짜 : 2025/01/17
 """
 
 import pymysql
@@ -717,7 +717,6 @@ def fetch_all_other_documents(pid):
         cur.close()
         connection.close()
 
-
 # 특정 기타 산출물을 조회하는 함수
 # 산출물 고유 번호를 매게 변수로 받는다
 def fetch_one_other_documents(file_unique_id):
@@ -734,6 +733,23 @@ def fetch_one_other_documents(file_unique_id):
     except Exception as e:
         print(f"Error [fetch_one_other_documents] : {e}")
         return None
+    finally:
+        cur.close()
+        connection.close()
+
+# 기타 산출물 테이블에서 산출물의 종류를 확인하는 함수
+# 산출물 고유 번호를 매개 변수로 받는다
+def fetch_document_type(file_unique_id):
+    connection = db_connect()
+    cur = connection.cursor(pymysql.cursors.DictCursor)
+
+    try:
+        cur.execute("SELECT SUBSTRING_INDEX(SUBSTRING_INDEX(file_path, '/', 5), '/', -1) AS doc_type FROM doc_other WHERE file_no = %s", (file_unique_id,))
+        result = cur.fetchone()
+        return result['doc_type']
+    except Exception as e:
+        print(f"Error [fetch_document_type] : {e}")
+        return e
     finally:
         cur.close()
         connection.close()

--- a/wbs_DB.py
+++ b/wbs_DB.py
@@ -85,7 +85,8 @@ def fetch_wbs_ratio(pid):
                 WHEN 3 THEN '설계'
                 WHEN 4 THEN '구현'
                 WHEN 5 THEN '테스트'
-                WHEN 6 THEN '유지보수' END AS group1,
+                WHEN 6 THEN '유지보수'
+                ELSE '기타' END AS group1,
             CAST(ROUND(AVG(ratio)) AS UNSIGNED) AS ratio
         FROM progress
         WHERE p_no = %s

--- a/wbs_DB.py
+++ b/wbs_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : wbs_DB.py
-    마지막 수정 날짜 : 2025/01/17
+    마지막 수정 날짜 : 2025/01/18
 """
 
 import pymysql

--- a/wbs_DB.py
+++ b/wbs_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : wbs_DB.py
-    마지막 수정 날짜 : 2025/01/16
+    마지막 수정 날짜 : 2025/01/17
 """
 
 import pymysql
@@ -86,7 +86,7 @@ def fetch_wbs_ratio(pid):
                 WHEN 4 THEN '구현'
                 WHEN 5 THEN '테스트'
                 WHEN 6 THEN '유지보수' END AS group1,
-            ROUND(AVG(ratio)) AS ratio
+            CAST(ROUND(AVG(ratio)) AS UNSIGNED) AS ratio
         FROM progress
         WHERE p_no = %s
         GROUP BY group1no

--- a/wbs_DB.py
+++ b/wbs_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : wbs_DB.py
-    마지막 수정 날짜 : 2025/01/05
+    마지막 수정 날짜 : 2025/01/16
 """
 
 import pymysql
@@ -65,6 +65,37 @@ def delete_all_wbs(pid):
     except Exception as e:
         connection.rollback()
         print(f"Error [delete_all_wbs] : {e}")
+        return e
+    finally:
+        cur.close()
+        connection.close()
+
+# 특정 프로젝트의 WBS에서 대분류 항목별로 진척률의 평균을 조회하는 함수
+# 프로젝트 번호를 매개 변수로 받는다
+def fetch_wbs_ratio(pid):
+    connection = db_connect()
+    cur = connection.cursor(pymysql.cursors.DictCursor)
+
+    try:
+        fetch_wbs_ratio = """
+        SELECT group1no,
+            CASE group1no
+                WHEN 1 THEN '계획'
+                WHEN 2 THEN '분석'
+                WHEN 3 THEN '설계'
+                WHEN 4 THEN '구현'
+                WHEN 5 THEN '테스트'
+                WHEN 6 THEN '유지보수' END AS group1,
+            ROUND(AVG(ratio)) AS ratio
+        FROM progress
+        WHERE p_no = %s
+        GROUP BY group1no
+        """
+        cur.execute(fetch_wbs_ratio, (pid,))
+        result = cur.fetchall()
+        return result
+    except Exception as e:
+        print(f"Error [fetch_wbs_ratio] : {e}")
         return e
     finally:
         cur.close()

--- a/wbs_DB.py
+++ b/wbs_DB.py
@@ -78,19 +78,10 @@ def fetch_wbs_ratio(pid):
 
     try:
         fetch_wbs_ratio = """
-        SELECT group1no,
-            CASE group1no
-                WHEN 1 THEN '계획'
-                WHEN 2 THEN '분석'
-                WHEN 3 THEN '설계'
-                WHEN 4 THEN '구현'
-                WHEN 5 THEN '테스트'
-                WHEN 6 THEN '유지보수'
-                ELSE '기타' END AS group1,
-            CAST(ROUND(AVG(ratio)) AS UNSIGNED) AS ratio
+        SELECT group1no, group1, CAST(ROUND(AVG(ratio)) AS UNSIGNED) AS ratio
         FROM progress
         WHERE p_no = %s
-        GROUP BY group1no
+        GROUP BY group1no, group1
         """
         cur.execute(fetch_wbs_ratio, (pid,))
         result = cur.fetchall()


### PR DESCRIPTION
## Summary
- [X] `wbs_DB.py` 에서 대분류 항목별로 진척률의 평균을 조회하는 쿼리 및 함수를 구현하였습니다.
- [X] `output_DB.py` 에서 기타 산출물 테이블의 산출물 종류를 확인하는 쿼리 및 함수를 구현하였습니다.

## Description
- `def fetch_wbs_ratio(pid)`
  - 정수 부분까지 반올림하고, 정수로 형변환하여 소수점 부분이 조회되지 않도록 하였습니다.
  - 조회되는 컬럼은 대분류 번호, 대분류 항목 이름, 진척률의 평균 총 3개입니다.

> [!NOTE]
> 진척률의 평균을 조회할 때, 소수점 부분까지 조회할 것인지와 뒤에 `%` 기호를 붙여서 조회할 것인지 등에 대하여 이미르 팀원님과 의견을 나누고, 쿼리 및 함수를 구현 및 수정하였습니다.
> 또한, 만약 이미르 팀원님이 프론트엔드 단에서 먼저 구현하신 것과 비교하였을 때, 성능/속도 면에서 별로 차이가 없다면, 저는 미르님이 구현하신 로직을 사용하는 방향으로 가는 것이 좋을 것 같습니다.

- `def fetch_document_type(file_unique_id)`
  - 산출물 고유 번호 `file_unique_id` 를 매개 변수로 받습니다.
  - MySQL DBMS 에서 기본적으로 제공하는 `SUBSTRING_INDEX()` 함수를 사용하였고, `/` 를 구분자로 하여 문자열을 자르는 원리이며, 파일 경로의 `WBS, OD, RS, MM, ETC` 등의 문자열을 반환합니다.

> [!TIP]
> 작년 2학기 방학하기 전(학기중)에 강의실에서 교수님과 미팅하는 날에 팀장님께서 기타 산출물 테이블에서 각 산출물이 어떤 종류의 산출물인지 확인하기 위한 방법이 필요하다고 말씀하셨었던 적이 있었습니다.
> 그 때, 제가 `SUBSTR` 관련 함수를 사용하는 방법이 있다고 말씀드린 적이 있었는데, 그에 대한 쿼리 및 함수입니다.
> 혹시, 만약 나중에 이 함수가 필요한 경우가 생겼을 때 사용하면 될 것 같습니다. :)