### PR TITLE
[Normal] 교수 테이블 생성 및 교번 외래키 설정, 교수 계정 관련 쿼리 및 함수 구현, Etc

### DIFF
--- a/PMS_Tables_Define.sql
+++ b/PMS_Tables_Define.sql
@@ -69,7 +69,8 @@ CREATE TABLE project (
  p_start DATE NOT NULL,
  p_end DATE NOT NULL,
  p_wizard BOOLEAN NULL,
- dno INT NOT NULL
+ dno INT NOT NULL,
+ f_no INT NULL
 );
 
 CREATE TABLE work (

--- a/PMS_Tables_Define.sql
+++ b/PMS_Tables_Define.sql
@@ -177,11 +177,11 @@ ALTER TABLE student ADD CONSTRAINT FK_dept_TO_student_1 FOREIGN KEY (dno) REFERE
 ALTER TABLE professor ADD CONSTRAINT FK_dept_TO_professor_1 FOREIGN KEY (dno) REFERENCES dept (dno);
 ALTER TABLE project_user ADD CONSTRAINT FK_project_TO_project_user_1 FOREIGN KEY (p_no) REFERENCES project (p_no) ON DELETE CASCADE;
 ALTER TABLE project_user ADD CONSTRAINT FK_student_TO_project_user_1 FOREIGN KEY (s_no) REFERENCES student (s_no) ON DELETE CASCADE;
-ALTER TABLE project_user ADD CONSTRAINT FK_professor_TO_project_user_1 FOREIGN KEY (f_no) REFERENCES professor (f_no) ON DELETE SET NULL;
 ALTER TABLE doc_other ADD CONSTRAINT FK_student_TO_doc_other_1 FOREIGN KEY (s_no) REFERENCES student (s_no);
 ALTER TABLE doc_other ADD CONSTRAINT FK_project_TO_doc_other_1 FOREIGN KEY (p_no) REFERENCES project (p_no) ON DELETE CASCADE;
 ALTER TABLE progress ADD CONSTRAINT FK_project_TO_progress_1 FOREIGN KEY (p_no) REFERENCES project (p_no) ON DELETE CASCADE;
 ALTER TABLE project ADD CONSTRAINT FK_dept_TO_project_1 FOREIGN KEY (dno) REFERENCES dept (dno);
+ALTER TABLE project ADD CONSTRAINT FK_professor_TO_project_1 FOREIGN KEY (f_no) REFERENCES professor (f_no) ON DELETE SET NULL;
 ALTER TABLE work ADD CONSTRAINT FK_project_user_TO_work FOREIGN KEY (p_no, s_no) REFERENCES project_user (p_no, s_no) ON DELETE CASCADE;
 ALTER TABLE doc_require ADD CONSTRAINT FK_project_TO_doc_require_1 FOREIGN KEY (p_no) REFERENCES project (p_no) ON DELETE CASCADE;
 ALTER TABLE doc_meeting ADD CONSTRAINT FK_project_TO_doc_meeting_1 FOREIGN KEY (p_no) REFERENCES project (p_no) ON DELETE CASCADE;

--- a/PMS_Tables_Define.sql
+++ b/PMS_Tables_Define.sql
@@ -11,12 +11,14 @@ CREATE TABLE student (
  dno INT NOT NULL
 );
 
-CREATE TABLE admin (
- a_id VARCHAR(20) NOT NULL PRIMARY KEY,
- a_pw VARCHAR(255) NOT NULL,
- a_name VARCHAR(20) NOT NULL,
- a_email VARCHAR(255) NOT NULL,
- a_token VARCHAR(30) NULL UNIQUE
+CREATE TABLE professor (
+ f_no INT NOT NULL PRIMARY KEY,
+ f_id VARCHAR(20) NOT NULL UNIQUE,
+ f_pw VARCHAR(255) NOT NULL,
+ f_name VARCHAR(20) NOT NULL,
+ f_email VARCHAR(255) NOT NULL,
+ f_token VARCHAR(30) NULL UNIQUE,
+ dno INT NOT NULL
 );
 
 CREATE TABLE project_user (
@@ -171,8 +173,10 @@ CREATE TABLE permission (
 );
 
 ALTER TABLE student ADD CONSTRAINT FK_dept_TO_student_1 FOREIGN KEY (dno) REFERENCES dept (dno);
+ALTER TABLE professor ADD CONSTRAINT FK_dept_TO_professor_1 FOREIGN KEY (dno) REFERENCES dept (dno);
 ALTER TABLE project_user ADD CONSTRAINT FK_project_TO_project_user_1 FOREIGN KEY (p_no) REFERENCES project (p_no) ON DELETE CASCADE;
 ALTER TABLE project_user ADD CONSTRAINT FK_student_TO_project_user_1 FOREIGN KEY (s_no) REFERENCES student (s_no) ON DELETE CASCADE;
+ALTER TABLE project_user ADD CONSTRAINT FK_professor_TO_project_user_1 FOREIGN KEY (f_no) REFERENCES professor (f_no) ON DELETE SET NULL;
 ALTER TABLE doc_other ADD CONSTRAINT FK_student_TO_doc_other_1 FOREIGN KEY (s_no) REFERENCES student (s_no);
 ALTER TABLE doc_other ADD CONSTRAINT FK_project_TO_doc_other_1 FOREIGN KEY (p_no) REFERENCES project (p_no) ON DELETE CASCADE;
 ALTER TABLE progress ADD CONSTRAINT FK_project_TO_progress_1 FOREIGN KEY (p_no) REFERENCES project (p_no) ON DELETE CASCADE;

--- a/account_DB.py
+++ b/account_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : account_DB.py
-    마지막 수정 날짜 : 2025/01/25
+    마지막 수정 날짜 : 2025/01/27
 """
 
 import pymysql
@@ -198,6 +198,36 @@ def validate_professor_token(id, Token):
             return False
     except Exception as e:
         print(f"Error [validate_professor_token] : {e}")
+        return e
+    finally:
+        cur.close()
+        connection.close()
+
+# 현재 사용자 계정이 학생 또는 교수인지 판단하는 함수
+# 토큰을 매개 변수로 받으며, 학생이면 1을 반환하고, 교수이면 2를 반환한다
+def check_user_type(Token):
+    connection = db_connect()
+    cur = connection.cursor(pymysql.cursors.DictCursor)
+
+    try:
+        cur.execute("SELECT COUNT(*) AS cnt FROM student WHERE s_token = %s", (Token,))
+        student = cur.fetchone()
+
+        cur.execute("SELECT COUNT(*) AS cnt FROM professor WHERE f_token = %s", (Token,))
+        professor = cur.fetchone()
+
+        if student['cnt'] == 1 and professor['cnt'] == 0:
+            return 1
+        elif student['cnt'] == 0 and professor['cnt'] == 1:
+            return 2
+        elif student['cnt'] == 0 and professor['cnt'] == 0:
+            print(f"Warning [check_user_type] : Token [{Token}] value is not exist in DB. (Student Count : {student['cnt']}, Professor Count : {professor['cnt']})")
+            return 0
+        else:
+            print(f"Warning [check_user_type] : Token [{Token}] value is unknown user type. (Student Count : {student['cnt']}, Professor Count : {professor['cnt']})")
+            return 0
+    except Exception as e:
+        print(f"Error [check_user_type] : {e}")
         return e
     finally:
         cur.close()

--- a/csv_DB.py
+++ b/csv_DB.py
@@ -58,6 +58,8 @@ def export_csv(pid):
 
         save_csv_doc_other = f"SELECT file_no, file_name, file_path, file_date, s_no, p_no FROM doc_other WHERE p_no = {pid} INTO OUTFILE '{csv_path}doc_o_{pid}_{save_time}.csv' FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n'"
         cur.execute(save_csv_doc_other)
+
+        print(f"Info : DB에 저장된 프로젝트 관련 정보를 모두 CSV 파일로 정상적으로 내보냈습니다. 내보낸 시간 : [{save_time}]")
         return True
     except Exception as e:
         print(f"Error [export_csv] : {e}")

--- a/csv_DB.py
+++ b/csv_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : csv_DB.py
-    마지막 수정 날짜 : 2025/01/25
+    마지막 수정 날짜 : 2025/01/26
 """
 
 import pymysql
@@ -26,10 +26,10 @@ def export_csv(pid):
         save_csv_professor = f"SELECT f_no, f_id, f_pw, f_name, f_email, dno FROM professor INTO OUTFILE '{csv_path}professor_{pid}_{save_time}.csv' FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n'"
         cur.execute(save_csv_professor)
 
-        save_csv_project = f"SELECT p_no, p_name, p_content, p_method, p_memcount, p_start, p_end, p_wizard, dno FROM project WHERE p_no = {pid} INTO OUTFILE '{csv_path}project_{pid}_{save_time}.csv' FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n'"
+        save_csv_project = f"SELECT p_no, p_name, p_content, p_method, p_memcount, p_start, p_end, p_wizard, dno, f_no FROM project WHERE p_no = {pid} INTO OUTFILE '{csv_path}project_{pid}_{save_time}.csv' FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n'"
         cur.execute(save_csv_project)
 
-        save_csv_project_user = f"SELECT p_no, s_no, permission, role, grade, comment, f_no FROM project_user WHERE p_no = {pid} INTO OUTFILE '{csv_path}project_user_{pid}_{save_time}.csv' FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n'"
+        save_csv_project_user = f"SELECT p_no, s_no, permission, role, grade, comment FROM project_user WHERE p_no = {pid} INTO OUTFILE '{csv_path}project_user_{pid}_{save_time}.csv' FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n'"
         cur.execute(save_csv_project_user)
 
         save_csv_permission = f"SELECT p_no, s_no, leader, ro, user, wbs, od, mm, ut, rs, rp, om, task, llm FROM permission WHERE p_no = {pid} INTO OUTFILE '{csv_path}permission_{pid}_{save_time}.csv' FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n'"
@@ -118,7 +118,7 @@ def import_csv(file_paths, pid):
 
         if "project" in file_paths:
             try:
-                load_csv_project = f"LOAD DATA INFILE '{file_paths['project']}' INTO TABLE project FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n' (p_no, p_name, p_content, p_method, p_memcount, p_start, p_end, p_wizard, dno)"
+                load_csv_project = f"LOAD DATA INFILE '{file_paths['project']}' INTO TABLE project FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n' (p_no, p_name, p_content, p_method, p_memcount, p_start, p_end, p_wizard, dno, f_no)"
                 cur.execute(load_csv_project)
                 import_ok.append("project")
             except Exception as e:
@@ -127,7 +127,7 @@ def import_csv(file_paths, pid):
 
         if "project_user" in file_paths:
             try:
-                load_csv_project_user = f"LOAD DATA INFILE '{file_paths['project_user']}' INTO TABLE project_user FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n' (p_no, s_no, permission, role, grade, comment, f_no)"
+                load_csv_project_user = f"LOAD DATA INFILE '{file_paths['project_user']}' INTO TABLE project_user FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n' (p_no, s_no, permission, role, grade, comment)"
                 cur.execute(load_csv_project_user)
                 import_ok.append("project_user")
             except Exception as e:

--- a/csv_DB.py
+++ b/csv_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : csv_DB.py
-    마지막 수정 날짜 : 2025/01/23
+    마지막 수정 날짜 : 2025/01/25
 """
 
 import pymysql
@@ -23,10 +23,13 @@ def export_csv(pid):
         save_csv_student = f"SELECT s_no, s_id, s_pw, s_name, s_email, dno FROM student INTO OUTFILE '{csv_path}student_{pid}_{save_time}.csv' FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n'"
         cur.execute(save_csv_student)
 
+        save_csv_professor = f"SELECT f_no, f_id, f_pw, f_name, f_email, dno FROM professor INTO OUTFILE '{csv_path}professor_{pid}_{save_time}.csv' FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n'"
+        cur.execute(save_csv_professor)
+
         save_csv_project = f"SELECT p_no, p_name, p_content, p_method, p_memcount, p_start, p_end, p_wizard, dno FROM project WHERE p_no = {pid} INTO OUTFILE '{csv_path}project_{pid}_{save_time}.csv' FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n'"
         cur.execute(save_csv_project)
 
-        save_csv_project_user = f"SELECT p_no, s_no, permission, role, grade, comment FROM project_user WHERE p_no = {pid} INTO OUTFILE '{csv_path}project_user_{pid}_{save_time}.csv' FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n'"
+        save_csv_project_user = f"SELECT p_no, s_no, permission, role, grade, comment, f_no FROM project_user WHERE p_no = {pid} INTO OUTFILE '{csv_path}project_user_{pid}_{save_time}.csv' FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n'"
         cur.execute(save_csv_project_user)
 
         save_csv_permission = f"SELECT p_no, s_no, leader, ro, user, wbs, od, mm, ut, rs, rp, om, task, llm FROM permission WHERE p_no = {pid} INTO OUTFILE '{csv_path}permission_{pid}_{save_time}.csv' FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n'"
@@ -67,6 +70,7 @@ def export_csv(pid):
 # {산출물 종류(문자열) : CSV 파일 경로(문자열)} 형태의 딕셔너리를 매개 변수로 받아서 CSV 파일의 내용을 DB에 저장한다
 # csv_dict = {
 #     "student" : "/var/lib/mysql/csv/student_10001_250105-153058.csv",
+#     "professor" : "/var/lib/mysql/csv/professor_10001_250105-153058.csv",
 #     "project" : "/var/lib/mysql/csv/project_10001_250105-153058.csv",
 #     "project_user" : "/var/lib/mysql/csv/project_user_10001_250105-153058.csv",
 #     "permission" : "/var/lib/mysql/csv/permission_10001_250105-153058.csv",
@@ -101,6 +105,15 @@ def import_csv(file_paths, pid):
                 print(f"Error [import_csv :: student] : {e}")
                 import_fail.append("student")
 
+        if "professor" in file_paths:
+            try:
+                load_csv_professor = f"LOAD DATA INFILE '{file_paths['professor']}' IGNORE INTO TABLE professor FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n' (f_no, f_id, f_pw, f_name, f_email, dno)"
+                cur.execute(load_csv_professor)
+                import_ok.append("professor")
+            except Exception as e:
+                print(f"Error [import_csv :: professor] : {e}")
+                import_fail.append("professor")
+
         if "project" in file_paths:
             try:
                 load_csv_project = f"LOAD DATA INFILE '{file_paths['project']}' INTO TABLE project FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n' (p_no, p_name, p_content, p_method, p_memcount, p_start, p_end, p_wizard, dno)"
@@ -112,7 +125,7 @@ def import_csv(file_paths, pid):
 
         if "project_user" in file_paths:
             try:
-                load_csv_project_user = f"LOAD DATA INFILE '{file_paths['project_user']}' INTO TABLE project_user FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n' (p_no, s_no, permission, role, grade, comment)"
+                load_csv_project_user = f"LOAD DATA INFILE '{file_paths['project_user']}' INTO TABLE project_user FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n' (p_no, s_no, permission, role, grade, comment, f_no)"
                 cur.execute(load_csv_project_user)
                 import_ok.append("project_user")
             except Exception as e:

--- a/project_DB.py
+++ b/project_DB.py
@@ -150,16 +150,16 @@ def delete_project(pid):
 # 프로젝트 참여자 추가(팀원 초대) 함수
 # 프로젝트 번호, 학번, PM 권한 여부(0/1), 역할을 매개 변수로 받는다
 # 주의사항 : 초대하려는 사용자(학생)는 회원가입이 이미 완료되어 있어야 한다
-def add_project_user(pid, univ_id, permission, role):
+def add_project_user(pid, univ_id, permission, role, f_no):
     connection = db_connect()
     cur = connection.cursor(pymysql.cursors.DictCursor)
 
     try:
         add_project_user = """
-        INSERT INTO project_user(p_no, s_no, permission, role, grade, comment)
-        VALUES (%s, %s, %s, %s, NULL, NULL)
+        INSERT INTO project_user(p_no, s_no, permission, role, grade, comment, f_no)
+        VALUES (%s, %s, %s, %s, NULL, NULL, %s)
         """
-        cur.execute(add_project_user, (pid, univ_id, permission, role))
+        cur.execute(add_project_user, (pid, univ_id, permission, role, f_no))
         connection.commit()
         return True
     except Exception as e:

--- a/project_DB.py
+++ b/project_DB.py
@@ -21,10 +21,9 @@ def init_project(payload, pid):
 
     try:
         add_project = """
-        INSERT INTO project(p_no, p_name, p_content, p_method, p_memcount, p_start, p_end, p_wizard, dno)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+        INSERT INTO project(p_no, p_name, p_content, p_method, p_memcount, p_start, p_end, p_wizard, dno, f_no)
         """
-        cur.execute(add_project, (pid, payload.pname, payload.pdetails, payload.pmm, payload.psize, p_startD, p_endD, payload.wizard, 10))
+        cur.execute(add_project, (pid, payload.pname, payload.pdetails, payload.pmm, payload.psize, p_startD, p_endD, payload.wizard, 10, payload.prof_id))
         connection.commit()
         return True
     except Exception as e:

--- a/project_DB.py
+++ b/project_DB.py
@@ -148,7 +148,7 @@ def delete_project(pid):
         connection.close()
 
 # 프로젝트 참여자 추가(팀원 초대) 함수
-# 프로젝트 번호, 학번, PM 권한 여부(0/1), 역할을 매개 변수로 받는다
+# 프로젝트 번호, 학번, PM 권한 여부(0/1), 역할, 담당 교수의 교번을 매개 변수로 받는다
 # 주의사항 : 초대하려는 사용자(학생)는 회원가입이 이미 완료되어 있어야 한다
 def add_project_user(pid, univ_id, permission, role, f_no):
     connection = db_connect()

--- a/project_DB.py
+++ b/project_DB.py
@@ -55,10 +55,11 @@ def edit_project(payload):
             p_start = %s,
             p_end = %s,
             p_wizard = %s,
-            dno = %s
+            dno = %s,
+            f_no = %s            
         WHERE p_no = %s
         """
-        cur.execute(edit_project, (payload.pname, payload.pdetails, payload.pmm, payload.psize, p_startD, p_endD, payload.wizard, 10, payload.pid))
+        cur.execute(edit_project, (payload.pname, payload.pdetails, payload.pmm, payload.psize, p_startD, p_endD, payload.wizard, 10, payload.prof_id, payload.pid))
         connection.commit()
         return True
     except Exception as e:

--- a/project_DB.py
+++ b/project_DB.py
@@ -102,8 +102,8 @@ def fetch_project_info_for_professor(f_no):
         fetch_project_info_for_professor = """
         SELECT p_no, p_name, p_content, p_method, p_memcount, p_start, p_end, p_wizard
         FROM project
-        WHERE p_no IN (SELECT DISTINCT p_no
-            FROM project_user
+        WHERE p_no IN (SELECT p_no
+            FROM project
             WHERE f_no = %s);
         """
         cur.execute(fetch_project_info_for_professor, (f_no,))

--- a/project_DB.py
+++ b/project_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : project_DB.py
-    마지막 수정 날짜 : 2025/01/25
+    마지막 수정 날짜 : 2025/01/26
 """
 
 import pymysql
@@ -100,10 +100,11 @@ def fetch_project_info_for_professor(f_no):
 
     try:
         fetch_project_info_for_professor = """
-        SELECT DISTINCT p.p_no, p.p_name, p.p_content, p.p_method, p.p_memcount, p.p_start, p.p_end, p.p_wizard
-        FROM project p, project_user u
-        WHERE p.p_no = u.p_no
-        AND u.f_no = %s
+        SELECT p_no, p_name, p_content, p_method, p_memcount, p_start, p_end, p_wizard
+        FROM project
+        WHERE p_no IN (SELECT DISTINCT p_no
+            FROM project_user
+            WHERE f_no = %s);
         """
         cur.execute(fetch_project_info_for_professor, (f_no,))
         result = cur.fetchall()

--- a/project_DB.py
+++ b/project_DB.py
@@ -100,7 +100,7 @@ def fetch_project_info_for_professor(f_no):
 
     try:
         fetch_project_info_for_professor = """
-        SELECT p.p_no, p.p_name, p.p_content, p.p_method, p.p_memcount, p.p_start, p.p_end, p.p_wizard
+        SELECT DISTINCT p.p_no, p.p_name, p.p_content, p.p_method, p.p_memcount, p.p_start, p.p_end, p.p_wizard
         FROM project p, project_user u
         WHERE p.p_no = u.p_no
         AND u.f_no = %s

--- a/project_DB.py
+++ b/project_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : project_DB.py
-    마지막 수정 날짜 : 2025/01/23
+    마지막 수정 날짜 : 2025/01/25
 """
 
 import pymysql
@@ -87,6 +87,29 @@ def fetch_project_info(univ_id):
         return result
     except Exception as e:
         print(f"Error [fetch_project_info] : {e}")
+        return e
+    finally:
+        cur.close()
+        connection.close()
+
+# 프로젝트 정보 조회 함수 (교수 전용)
+# 교수의 교번을 매개 변수로 받아서 교수가 담당하고 있는 학생의 모든 프로젝트를 조회한다
+def fetch_project_info_for_professor(f_no):
+    connection = db_connect()
+    cur = connection.cursor(pymysql.cursors.DictCursor)
+
+    try:
+        fetch_project_info_for_professor = """
+        SELECT p.p_no, p.p_name, p.p_content, p.p_method, p.p_memcount, p.p_start, p.p_end, p.p_wizard
+        FROM project p, project_user u
+        WHERE p.p_no = u.p_no
+        AND u.f_no = %s
+        """
+        cur.execute(fetch_project_info_for_professor, (f_no,))
+        result = cur.fetchall()
+        return result
+    except Exception as e:
+        print(f"Error [fetch_project_info_for_professor] : {e}")
         return e
     finally:
         cur.close()

--- a/project_DB.py
+++ b/project_DB.py
@@ -171,14 +171,14 @@ def add_project_user(pid, univ_id, permission, role, f_no):
         connection.close()
 
 # 프로젝트 참여자 수정(팀원 정보 수정) 함수
-# 수정하려는 팀원의 학번, 프로젝트 번호, 역할을 매개 변수로 받는다
-def edit_project_user(univ_id, pid, role):
+# 수정하려는 팀원의 학번, 프로젝트 번호, 역할, 담당 교수의 교번을 매개 변수로 받는다
+def edit_project_user(univ_id, pid, role, f_no):
     connection = db_connect()
     cur = connection.cursor(pymysql.cursors.DictCursor)
 
     try:
         # 프로젝트 참여 테이블에서 프로젝트 번호와 학번으로 수정할 팀원을 선택하고 역할을 수정
-        cur.execute("UPDATE project_user SET role = %s WHERE p_no = %s AND s_no = %s", (role, pid, univ_id))
+        cur.execute("UPDATE project_user SET role = %s, f_no = %s WHERE p_no = %s AND s_no = %s", (role, f_no, pid, univ_id))
         connection.commit()
         return True
     except Exception as e:

--- a/project_DB.py
+++ b/project_DB.py
@@ -149,18 +149,18 @@ def delete_project(pid):
         connection.close()
 
 # 프로젝트 참여자 추가(팀원 초대) 함수
-# 프로젝트 번호, 학번, PM 권한 여부(0/1), 역할, 담당 교수의 교번을 매개 변수로 받는다
+# 프로젝트 번호, 학번, PM 권한 여부(0/1), 역할을 매개 변수로 받는다
 # 주의사항 : 초대하려는 사용자(학생)는 회원가입이 이미 완료되어 있어야 한다
-def add_project_user(pid, univ_id, permission, role, f_no):
+def add_project_user(pid, univ_id, permission, role):
     connection = db_connect()
     cur = connection.cursor(pymysql.cursors.DictCursor)
 
     try:
         add_project_user = """
-        INSERT INTO project_user(p_no, s_no, permission, role, grade, comment, f_no)
-        VALUES (%s, %s, %s, %s, NULL, NULL, %s)
+        INSERT INTO project_user(p_no, s_no, permission, role, grade, comment)
+        VALUES (%s, %s, %s, %s, NULL, NULL)
         """
-        cur.execute(add_project_user, (pid, univ_id, permission, role, f_no))
+        cur.execute(add_project_user, (pid, univ_id, permission, role))
         connection.commit()
         return True
     except Exception as e:
@@ -172,14 +172,14 @@ def add_project_user(pid, univ_id, permission, role, f_no):
         connection.close()
 
 # 프로젝트 참여자 수정(팀원 정보 수정) 함수
-# 수정하려는 팀원의 학번, 프로젝트 번호, 역할, 담당 교수의 교번을 매개 변수로 받는다
-def edit_project_user(univ_id, pid, role, f_no):
+# 수정하려는 팀원의 학번, 프로젝트 번호, 역할을 매개 변수로 받는다
+def edit_project_user(univ_id, pid, role):
     connection = db_connect()
     cur = connection.cursor(pymysql.cursors.DictCursor)
 
     try:
         # 프로젝트 참여 테이블에서 프로젝트 번호와 학번으로 수정할 팀원을 선택하고 역할을 수정
-        cur.execute("UPDATE project_user SET role = %s, f_no = %s WHERE p_no = %s AND s_no = %s", (role, f_no, pid, univ_id))
+        cur.execute("UPDATE project_user SET role = %s WHERE p_no = %s AND s_no = %s", (role, pid, univ_id))
         connection.commit()
         return True
     except Exception as e:

--- a/project_DB.py
+++ b/project_DB.py
@@ -22,6 +22,7 @@ def init_project(payload, pid):
     try:
         add_project = """
         INSERT INTO project(p_no, p_name, p_content, p_method, p_memcount, p_start, p_end, p_wizard, dno, f_no)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         """
         cur.execute(add_project, (pid, payload.pname, payload.pdetails, payload.pmm, payload.psize, p_startD, p_endD, payload.wizard, 10, payload.prof_id))
         connection.commit()


### PR DESCRIPTION
## Summary
- [X] `PMS_Tables_Define.sql` 에서 다음과 같은 수정 작업을 진행하였습니다.
  - [X] 기존의 관리자 `admin` 테이블을 삭제하고, 교수 `professor` 테이블을 생성하였습니다.
  - [X] 프로젝트 `project` 테이블에 교번 `f_no` 외래키 컬럼을 추가하였습니다.
- [X] `account_DB.py` 에서 교수 계정 로그인, 로그인 후 토큰 저장, 로그아웃, 교수의 토큰 값을 확인, 현재 사용자 계정이 학생 또는 교수인지 판단하는 총 5개의 쿼리 및 함수를 구현하였습니다.
- [X] `project_DB.py` 에서 다음과 같은 수정 작업을 진행하였습니다.
  - [X] 교수 전용으로 사용되는 프로젝트 정보 조회 쿼리 및 함수를 구현하였습니다.
  - [X] 프로젝트를 생성, 수정하는 쿼리 및 함수를 수정하였습니다.
- [X] `csv_DB.py` 에서 프로젝트 Import/Export 기능에 교수 계정 정보, 프로젝트 테이블의 교번 외래키 컬럼도 포함되도록 수정하였습니다.

## Description
### `account_DB.py` 에서 새로 추가된 함수
- def validate_professor(id, pw)
- def save_signin_professor_token(id, Token)
- def signout_professor(Token)
- def validate_professor_token(id, Token)
- def check_user_type(Token)

### `project_DB.py` 에서 새로 추가/수정된 함수
#### 추가된 함수
- def fetch_project_info_for_professor(f_no)

#### 수정된 함수
- def init_project(payload, pid)
- def edit_project(payload)

> [!WARNING]
> 백엔드 API 서버의 `project.py` 에서 `class ProjectInit(BaseModel)`, `class ProjectEdit(BaseModel)` 클래스에 `prof_id` 필드가 추가되어 있어야 합니다.