### PR TITLE
[Severe] 프로젝트 정보를 저장하는 insert_csv_history 함수 및 쿼리 구현, 버그 수정 필요

### DIFF
--- a/csv_DB.py
+++ b/csv_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : csv_DB.py
-    마지막 수정 날짜 : 2025/02/01
+    마지막 수정 날짜 : 2025/02/04
 """
 
 import pymysql
@@ -253,7 +253,8 @@ def insert_csv_history(pid, univ_id, msg):
             cur.execute("SELECT COUNT(*) FROM sequences WHERE p_no = %s", (pid,))
             exists = cur.fetchone()[0]
             if exists == 0:
-                raise Exception("Failed to initialize sequence for pid")
+                print(f"Failed to initialize sequence")
+                return None
         cur.execute("SELECT nextval(%s)", (pid,))
         ver = cur.fetchone()[0]
         if ver is None:

--- a/csv_DB.py
+++ b/csv_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : csv_DB.py
-    마지막 수정 날짜 : 2025/02/04
+    마지막 수정 날짜 : 2025/02/05
 """
 
 import pymysql
@@ -10,9 +10,9 @@ from mysql_connection import db_connect
 import project_DB
 
 # 프로젝트 정보를 CSV 파일로 내보내는 함수
-# 프로젝트 번호, 현재 사용자의 학번, 메시지를 매개 변수로 받아서 해당 프로젝트의 정보, 업무, 진척도, 각 산출물 정보를 CSV 파일로 내보낸다
+# 프로젝트 번호를 매개 변수로 받아서 해당 프로젝트의 정보, 업무, 진척도, 각 산출물 정보를 CSV 파일로 내보낸다
 # 내보낸 CSV 파일은 /var/lib/mysql/csv/ 경로에 저장된다
-def export_csv(pid, univ_id, msg):
+def export_csv(pid):
     connection = db_connect()
     cur = connection.cursor(pymysql.cursors.DictCursor)
 
@@ -58,9 +58,6 @@ def export_csv(pid, univ_id, msg):
 
         save_csv_doc_other = f"SELECT file_no, file_name, file_path, file_date, s_no, p_no FROM doc_other WHERE p_no = {pid} INTO OUTFILE '{csv_path}doc_o_{pid}_{save_time}.csv' FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '^' LINES TERMINATED BY '\\n'"
         cur.execute(save_csv_doc_other)
-
-        save_history = f"INSERT INTO history (p_no, ver, date, s_no, msg) VALUES ({pid}, nextval({pid}), NOW(), {univ_id}, '{msg}')"
-        cur.execute(save_history)
 
         connection.commit()
         print(f"Info : DB에 저장된 프로젝트 관련 정보를 모두 CSV 파일로 정상적으로 내보냈습니다. 내보낸 시간 : [{save_time}]")

--- a/csv_DB.py
+++ b/csv_DB.py
@@ -86,11 +86,11 @@ def export_csv(pid):
 #     "doc_report" : "/var/lib/mysql/csv/doc_rep_10001_250105-153058.csv",
 #     "doc_other" : "/var/lib/mysql/csv/doc_o_10001_250105-153058.csv"
 # }
-# 위와 같이 딕셔너리를 만들고, import_csv(csv_dict, pid, univ_id, 'Revert z to x') 와 같이 함수를 호출하여 사용한다
+# 위와 같이 딕셔너리를 만들고, import_csv(csv_dict, pid) 와 같이 함수를 호출하여 사용한다
 # 참고 : pid 매개 변수는 프로젝트를 Import 하기 전에 기존의 프로젝트 내용을 삭제하는 데에 사용된다
 # 참고 : 딕셔너리의 키는 수정이 불가능하며, CSV 파일은 /var/lib/mysql/csv 경로에 저장되어 있어야 한다
 # 참고 : msg 매개 변수는 API 서버로부터 'Revert z to x' 형태의 문자열을 그대로 받는다
-def import_csv(file_paths, pid, univ_id, msg):
+def import_csv(file_paths, pid):
     connection = db_connect()
     cur = connection.cursor(pymysql.cursors.DictCursor)
 
@@ -98,7 +98,6 @@ def import_csv(file_paths, pid, univ_id, msg):
     import_fail = []
 
     try:
-        export_csv(pid, univ_id, msg)
         project_DB.delete_project(pid)
 
         if "student" in file_paths:


### PR DESCRIPTION
## Summary
- csv_DB에 함수를 추가했습니다.

## Description
- history 테이블에 관련 데이터를 삽입하는 기능을 구현했습니다.
  - 만약 sequences 테이블에 해당 p_no가 존재하지 않으면 create_sequence 프로시저를 실행해 정상적으로 작동하게끔 구현했습니다.
  - nextval 함수를 실행해 ver의 값이 1씩 증가하게끔 구현했습니다.
  - 다음과 같은 버그(오류)가 존재합니다. 관련해서 코드 리뷰 부탁드리겠습니다.
- 현재 존재하는 버그
  - [API 서버에서 api_project_export 함수](https://github.com/kimch0612/Backend/blob/7b60cd523ad92a81f44806905b3114a3bccbbf9b/ccp.py#L214)를 실행하면 ver의 값이 중복으로 들어가는 (2씩 증가하는) 문제가 발생합니다.
    - 아마 DB의 export_csv 함수에서도 1을 증가시키고, insert_csv_history 함수에서도 1을 증가시켜서 충돌을 일으키는 것 같은데 (api_project_export 함수에서 export_csv를 비활성화하면 1만 증가함) 이것저것 수정해봐도 버그가 잡히질 않아 그냥 PR을 열었습니다.
  ![image](https://github.com/user-attachments/assets/606f4af9-c44c-4d39-ad13-daeb9215b185)
  ![image](https://github.com/user-attachments/assets/e5ab8d1d-c039-4150-a783-b976ed2ca7c9)
  - export_csv 함수에서도 insert_csv_history 함수와 동일하게 sequences 테이블에 p_no가 존재하지 않으면 NULL 관련 오류가 발생하지 않을까 싶습니다.
    - 제가 수정해볼까 생각을 해봤는데, 잘 되는 코드가 괜히 꼬일까봐 따로 수정을 하지는 않았습니다.