### PR TITLE
[Normal] 테스트 케이스를 한 번에 입력 및 저장하는 방식으로 변경

### DIFF
--- a/PMS_Tables_Define.sql
+++ b/PMS_Tables_Define.sql
@@ -152,10 +152,12 @@ CREATE TABLE doc_summary (
 
 CREATE TABLE doc_test (
  doc_t_no INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+ doc_t_group1 VARCHAR(30) NULL,
  doc_t_name TEXT NOT NULL,
  doc_t_start DATE NOT NULL,
  doc_t_end DATE NOT NULL,
  doc_t_pass BOOLEAN NOT NULL,
+ doc_t_group1no INT NULL,
  p_no INT NOT NULL
 );
 


### PR DESCRIPTION
## Summary
- `PMS_Tables_Define.sql` 에서 테스트 케이스 `doc_test` 테이블에 테스트 분류, 테스트 분류 번호 2개의 컬럼을 추가하였습니다.
- `output_DB.py` 에서 기존의 테스트 케이스 관련 쿼리 및 함수를 삭제하고, WBS 처럼 한꺼번에 추가(저장), 삭제, 조회하는 쿼리 및 함수를 구현하였습니다.

## Description
- def add_multiple_testcase(testcase_data, pid)
  - WBS 관련 함수와 사용 방법이 거의 동일합니다.
- def delete_all_testcase(pid)
- def fetch_all_testcase(pid)

> [!TIP]
> 추가하려는 테스트 케이스의 항목이 모두 담긴 이차원 배열(리스트) 및 프로젝트 번호를 매개 변수로 받습니다.
> 
> ![image](https://github.com/user-attachments/assets/77378f3d-a5de-41eb-9d5a-5223a161e7af)
> ![image](https://github.com/user-attachments/assets/d8256363-b75a-4d3d-b8e6-f7492c2e2c71)