### PR TITLE
[Major] 프로젝트 생성 시 학과번호는 과목 코드 및 서브쿼리로 자동으로 입력되도록 수정

### DIFF
--- a/project_DB.py
+++ b/project_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : project_DB.py
-    마지막 수정 날짜 : 2025/02/18
+    마지막 수정 날짜 : 2025/02/26
 """
 
 import pymysql
@@ -22,9 +22,9 @@ def init_project(payload, pid):
     try:
         add_project = """
         INSERT INTO project(p_no, p_name, p_content, p_method, p_memcount, p_start, p_end, p_wizard, subj_no, dno, f_no)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, (SELECT dno FROM subject WHERE subj_no = %s), %s)
         """
-        cur.execute(add_project, (pid, payload.pname, payload.pdetails, payload.pmm, payload.psize, p_startD, p_endD, payload.wizard, payload.subject, 10, payload.prof_id))
+        cur.execute(add_project, (pid, payload.pname, payload.pdetails, payload.pmm, payload.psize, p_startD, p_endD, payload.wizard, payload.subject, payload.subject, payload.prof_id))
         cur.execute("CALL create_sequence(%s)", (pid,))
         connection.commit()
         return True


### PR DESCRIPTION
## Summary
- `project_DB.py` 의 프로젝트 생성 함수 `init_project()` 에서 학과번호는 과목 코드 및 서브쿼리를 사용하여 자동으로 입력되도록 수정하였습니다.
  - https://github.com/CodeCraft-NSU/Database/issues/62

## Description
- 수정한 함수 : `init_project(payload, pid)`
  - INSERT 문의 VALUES 절에서 학과 번호 입력란에 서브쿼리를 사용하여 해당 과목의 학과 번호를 자동으로 입력합니다.