### PR TITLE
[Major] 프로젝트 번호로 담당 교수 조회 시 교번도 같이 출력되도록 수정

### DIFF
--- a/project_DB.py
+++ b/project_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : project_DB.py
-    마지막 수정 날짜 : 2025/02/26
+    마지막 수정 날짜 : 2025/03/19
 """
 
 import pymysql
@@ -120,14 +120,14 @@ def fetch_project_info_for_professor(f_no):
         cur.close()
         connection.close()
 
-# 프로젝트의 담당 교수 이름을 조회하는 함수
+# 특정 프로젝트의 담당 교수의 교번, 교수 이름을 조회하는 함수
 # 프로젝트 번호를 매개 변수로 받는다
 def fetch_project_professor_name(pid):
     connection = db_connect()
     cur = connection.cursor(pymysql.cursors.DictCursor)
 
     try:
-        cur.execute("SELECT f_name FROM professor WHERE f_no = (SELECT f_no FROM project WHERE p_no = %s)", (pid,))
+        cur.execute("SELECT f_no, f_name FROM professor WHERE f_no = (SELECT f_no FROM project WHERE p_no = %s)", (pid,))
         result = cur.fetchone()
         return result
     except Exception as e:


### PR DESCRIPTION
## Summary
- [X] `project_DB.py` 에서 프로젝트 번호로 담당 교수를 조회할 때, 교번도 같이 출력되도록 수정하였습니다.
  - https://github.com/CodeCraft-NSU/Database/issues/75

## Description
- 프로젝트 번호로 담당 교수를 조회할 때, 교번과 교수 이름 2개의 컬럼이 조회되어 반환됩니다.
  - `def fetch_project_professor_name(pid)`