### PR TITLE
[Major] 프로젝트 개요서 간단본을 모두 조회하는 함수에서 상세본까지 같이 조회되는 문제 해결

### DIFF
--- a/output_DB.py
+++ b/output_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : output_DB.py
-    마지막 수정 날짜 : 2025/03/24
+    마지막 수정 날짜 : 2025/03/26
 """
 
 import pymysql
@@ -71,7 +71,7 @@ def fetch_all_summary_documents(pid):
     cur = connection.cursor(pymysql.cursors.DictCursor)
 
     try:
-        cur.execute("SELECT * FROM doc_summary WHERE doc_s_outcomes IS NOT NULL AND p_no = %s", (pid,))
+        cur.execute("SELECT * FROM doc_summary WHERE doc_s_stack IS NULL AND p_no = %s", (pid,))
         result = cur.fetchall()
         return result
     except Exception as e:


### PR DESCRIPTION
## Summary
- [X] `output_DB.py` 의 프로젝트 개요서 간단본을 모두 조회하는 함수에서 상세본까지 같이 조회되는 문제를 해결하였습니다.
  - https://github.com/CodeCraft-NSU/Database/issues/83

## Description
- 단위 테스트를 진행한 결과, 프로젝트 개요서 간단본을 모두 조회하는 함수에서 상세본까지 같이 조회되는 버그를 발견하였습니다.
- 프로젝트 개요서 간단본만 모두 조회하는 쿼리문의 WHERE 절에서 상세본은 입력되지만, 간단본은 입력되지 않는 컬럼에 대하여 `doc_s_stack IS NULL` 연산자를 사용하여 필터링하는 방식으로 수정하였습니다.
- 상세본은 입력되지만, 간단본은 입력되지 않는 컬럼은 다음과 같습니다.
  - `doc_s_goals`
  - `doc_s_stack`

> [!NOTE]
> 현재, PMS 에서 사용중인 프로젝트 개요서는 상세본이므로, 위의 버그/문제의 영향을 받지 않습니다.
> 하지만, 단위 테스트를 진행한 후에 발견된 버그 수정은 필요하다고 생각되어 수정하였습니다.