### PR TITLE
[Normal] 선배 프로젝트 불러오기 기능에서 사용하기 위한 쿼리 및 함수 구현

### DIFF
--- a/project_DB.py
+++ b/project_DB.py
@@ -1,7 +1,7 @@
 """
     CodeCraft PMS Project
     파일명 : project_DB.py
-    마지막 수정 날짜 : 2025/03/19
+    마지막 수정 날짜 : 2025/04/13
 """
 
 import pymysql
@@ -384,6 +384,23 @@ def fetch_project_for_LLM(pid):
         return json.dumps(project_data, ensure_ascii=False, default=str)
     except Exception as e:
         print(f"Error [fetch_project_for_LLM] : {e}")
+        return e
+    finally:
+        cur.close()
+        connection.close()
+
+# 현재 날짜 기준으로 프로젝트 종료일이 지난 프로젝트의 정보를 조회하는 함수
+# 매개 변수는 없다
+def fetch_expired_projects():
+    connection = db_connect()
+    cur = connection.cursor(pymysql.cursors.DictCursor)
+
+    try:
+        cur.execute("SELECT * FROM project WHERE p_end < CURDATE()")
+        result = cur.fetchall()
+        return result
+    except Exception as e:
+        print(f"Error [fetch_expired_projects] : {e}")
         return e
     finally:
         cur.close()


### PR DESCRIPTION
## Summary
- [X] `project_DB.py` 에서 현재 날짜 기준으로 프로젝트 종료일이 지난 프로젝트의 정보를 조회하는 쿼리 및 함수를 구현하였습니다.
  - https://github.com/CodeCraft-NSU/Database/issues/87

## Description
- `def fetch_expired_projects()`
  - 매개 변수는 없습니다.
  - WHERE 절에서 `CURDATE()` 함수를 사용하여 현재 날짜를 기준으로 프로젝트 종료일이 지난 프로젝트를 필터링합니다.

> [!TIP]
> 백엔드 API 서버에서 프로젝트 종료일이 지난 프로젝트를 별도로 필터링하는 작업이 필요하지 않습니다. :)